### PR TITLE
Update of Learn-OCaml-Essok: managing archives of a Swift container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ocamlsf/learn-ocaml:latest
 
 USER root
-RUN apk add dumb-init py3-pip python3-dev gcc musl-dev linux-headers \
+RUN apk add dumb-init py3-pip zip unzip \
+            python3-dev gcc musl-dev linux-headers \
  && pip3 install --upgrade pip python-keystoneclient python-swiftclient \
  && apk del python3-dev gcc musl-dev linux-headers
 

--- a/program.sh
+++ b/program.sh
@@ -5,8 +5,11 @@ SYNC=sync
 download_repository() {
 	echo "swift download $1"
 	swift download $1
-	unzip $REPOSITORY.zip $SYNC.zip
-	rm $REPOSITORY.zip $SYNC.zip
+	unzip $REPOSITORY.zip
+	if [ -f $SYNC.zip ] then
+		unzip $SYNC.zip
+	fi
+	rm -f $REPOSITORY.zip $SYNC.zip
 }
 
 upload_repository() {

--- a/program.sh
+++ b/program.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
+REPOSITORY=repository
+SYNC=sync
 
 download_repository() {
 	echo "swift download $1"
 	swift download $1
+	unzip $REPOSITORY.zip $SYNC.zip
+	rm $REPOSITORY.zip $SYNC.zip
 }
 
 upload_repository() {
-	swift upload $1 repository/ sync/
-} 
+	zip $REPOSITORY.zip -r $REPOSITORY
+	zip $SYNC.zip -r $SYNC
+	echo "swift upload $1"
+	swift upload $1 $REPOSITORY.zip $SYNC.zip
+}
 
 trap 'kill -TERM $PID; wait $PID; upload_repository $1; exit 143' TERM
 

--- a/program.sh
+++ b/program.sh
@@ -5,17 +5,23 @@ SYNC=sync
 download_repository() {
 	echo "swift download $1"
 	swift download $1
-	unzip $REPOSITORY.zip
-	if [ -f $SYNC.zip ] then
-		unzip $SYNC.zip
+	unzip -q $REPOSITORY.zip
+	echo "unzipping $REPOSITORY.zip returns $?"
+	rm -f $REPOSITORY.zip
+	if [ -f $SYNC.zip ]
+	then
+		unzip -q $SYNC.zip
+		echo "unzipping $SYNC.zip returns $?"
+		rm -f $SYNC.zip
 	fi
-	rm -f $REPOSITORY.zip $SYNC.zip
 }
 
 upload_repository() {
-	zip $REPOSITORY.zip -r $REPOSITORY
-	zip $SYNC.zip -r $SYNC
-	echo "swift upload $1"
+	zip -q $REPOSITORY.zip -r $REPOSITORY
+	echo "zipping $REPOSITORY returns $?"
+	zip -q $SYNC.zip -r $SYNC
+	echo "zipping $SYNC returns $?"
+	echo "swift upload $1 $REPOSITORY.zip $SYNC.zip"
 	swift upload --changed $1 $REPOSITORY.zip $SYNC.zip
 }
 


### PR DESCRIPTION
This PR will take over the new archive system of Swift:
Instead of downloading directories "repository" and "sync", we will download archives "repository.zip" and "sync.zip"
The goal here is to extract with "unzip" before launching the Learn-OCaml instance, and compress then upload to Swift at the shutdown.