### PR TITLE
Fix learn-ocaml version to 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocamlsf/learn-ocaml:latest
+FROM ocamlsf/learn-ocaml:0.12
 
 USER root
 RUN apk add dumb-init py3-pip zip unzip \


### PR DESCRIPTION
This PR should set learn-ocaml version to 0.12, and allow safe & manual updates later.