### PR TITLE
Fix bad usage of `find`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+env.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocamlsf/learn-ocaml:0.12
+FROM ocamlsf/learn-ocaml:0.13.1
 
 USER root
 RUN apk add coreutils dumb-init py3-pip zip unzip \

--- a/program.sh
+++ b/program.sh
@@ -48,7 +48,10 @@ clone_sync() {
     echo "cloning sync to avoid concurrency when writing"
     for repo in $(find_repositories $SYNC)
     do
-        git clone --config user.name="Learn-OCaml user" "$repo" $BACKUP/"$repo"
+        git clone \
+            --config user.name="Learn-OCaml user" \
+            --config user.email="none@learn-ocaml.org" \
+            "$repo" $BACKUP/"$repo"
     done
     # copy directories which are not repositories yet
     echo "cp -rn $SYNC $BACKUP/$SYNC"

--- a/program.sh
+++ b/program.sh
@@ -27,27 +27,28 @@ download_repository() {
     fi
 }
 
+find_repositories() {
+    find "$1" -name .git -exec dirname {} \;
+}
+
 optimize_sync() {
     echo "optimizing using git gc"
-    cd "$SYNC" || error "optimizing_sync: cd $SYNC" || return
-    DIRS=$(find . -mindepth 4 -maxdepth 4 -type d -not -path "\./\.git*")
-    for i in $DIRS
+    for repo in $(find_repositories $SYNC)
     do
-        echo "$i"
-        cd "$i" || error "optimizing_sync: cd $i" || continue
+        echo "optimizing $repo"
+        cd "$repo" || error "optimizing_sync: cd $repo" || continue
         git gc
         cd - || error "optimizing_sync: cd - (assert false)" || continue
     done
-    git gc
-    cd ..
     echo "optimizing done"
 }
 
 clone_sync() {
     rm -rf ${BACKUP:?}/$SYNC
     echo "cloning sync to avoid concurrency when writing"
-    find $SYNC -name .git | while read -r repository; do
-        git clone "$repository" $BACKUP/"$repository"
+    for repo in $(find_repositories $SYNC)
+    do
+        git clone "$repo" $BACKUP/"$repo"
     done
     # copy directories which are not repositories yet
     echo "cp -rn $SYNC $BACKUP/$SYNC"

--- a/program.sh
+++ b/program.sh
@@ -48,7 +48,7 @@ clone_sync() {
     echo "cloning sync to avoid concurrency when writing"
     for repo in $(find_repositories $SYNC)
     do
-        git clone "$repo" $BACKUP/"$repo"
+        git clone --config user.name="Learn-OCaml user" "$repo" $BACKUP/"$repo"
     done
     # copy directories which are not repositories yet
     echo "cp -rn $SYNC $BACKUP/$SYNC"

--- a/program.sh
+++ b/program.sh
@@ -77,6 +77,9 @@ watch_upload() {
     sleep $BEGIN &
     PIDSLEEP=$!
     wait $PIDSLEEP
+    # In case the first sleep is killed
+    date
+    upload_repository "$1"
     while ! [ -f $STOP ]
     do
 	sleep $INTERVAL &


### PR DESCRIPTION
Fix #14 
The `find` command is fixed with a call to `dirname` on each directory.
An option `--config user.name="Learn-OCaml user"` is needed as `git clone` will not copy the config `user.name` of the repository. (maybe there is a better way to fix this ?).
Must be merged after #13 